### PR TITLE
improve get_formatted_duration to support more input types

### DIFF
--- a/expression/functions_date.go
+++ b/expression/functions_date.go
@@ -337,40 +337,34 @@ func getValueForCurrentDay(arguments ...interface{}) (interface{}, error) {
 }
 
 func getFormattedDuration(duration, inputUnit, format, separator, keepSeparator, printZeroValues interface{}) string {
-	durationTyped, ok := duration.(float64)
-	durationInt, ok2 := duration.(int)
+	durationTyped, err := convertAsFloat(duration)
 
-	if !ok && !ok2 {
-		return "error"
-	}
-
-	if ok2 {
-		durationTyped = float64(durationInt)
+	if err != nil {
+		return fmt.Sprintf("error parsing duration, value given is %v, of type %T", duration, duration)
 	}
 
 	inputUnitTyped, ok := inputUnit.(string)
 	if !ok {
-		return "error"
+		return fmt.Sprintf("error parsing inputUnit, type is %T", inputUnit)
 	}
 
 	formatTyped, ok := format.(string)
 	if !ok {
-		return "error"
+		return fmt.Sprintf("error parsing format, type is %T", format)
 	}
 
 	separatorTyped, ok := separator.(string)
 	if !ok {
-		return "error"
+		return fmt.Sprintf("error parsing separator, type is %T", separator)
 	}
 
-	keepSeparatorTyped, ok := keepSeparator.(bool)
-	if !ok {
-		return "error"
+	keepSeparatorTyped, err := convertAsBool(keepSeparator)
+	if err != nil {
+		return fmt.Sprintf("error parsing keepSeparator, type is %T", keepSeparator)
 	}
-
-	printZeroValuesTyped, ok := printZeroValues.(bool)
-	if !ok {
-		return "error"
+	printZeroValuesTyped, err := convertAsBool(printZeroValues)
+	if err != nil {
+		return fmt.Sprintf("error parsing printZeroValues, type is %T", printZeroValues)
 	}
 
 	return getFormattedDurationTyped(

--- a/expression/functions_date_test.go
+++ b/expression/functions_date_test.go
@@ -491,12 +491,14 @@ func TestGetFormattedDuration(t *testing.T) {
 		{"value kept in milliseconds", 1234567, "ms", "{ms} ms", "", false, false, "1234567 ms"},
 		{"invalid unit without print 0 values", 1000, "test", "{ms} ms", "", false, false, ""},
 		{"invalid unit with print 0 values", 1000, "test", "{ms} ms", "", false, true, "0 ms"},
-		{"invalid type for duration", 1000, 1, 100, 0, 1, 1, "error"},
-		{"invalid type for inputUnit", 1000, "test", 100, 0, 1, 1, "error"},
-		{"invalid type for format", 1000, "test", 100, 0, 1, 1, "error"},
-		{"invalid type for separator", 1000, "test", "", 0, 1, 1, "error"},
-		{"invalid type for keepSeparator", 1000, "test", "", "", 1, 1, "error"},
-		{"invalid type for printZeroValues", 1000, "test", "", "", true, 1, "error"},
+		{"convert day in string to minutes", "3", "d", "{m} minutes", "", false, false, "4320 minutes"},
+		{"convert day to minutes with boolean in string", "3", "d", "{m} minutes", "", "false", "false", "4320 minutes"},
+		{"invalid type for duration", "1000aaa", 1, 100, 0, 1, 1, "error parsing duration, value given is 1000aaa, of type string"},
+		{"invalid type for inputUnit", 1000, 1, 100, 0, 1, 1, "error parsing inputUnit, type is int"},
+		{"invalid type for format", 1000, "test", 100, 0, 1, 1, "error parsing format, type is int"},
+		{"invalid type for separator", 1000, "test", "", 0, 1, 1, "error parsing separator, type is int"},
+		{"invalid type for keepSeparator", 1000, "test", "", "", 1, 1, "error parsing keepSeparator, type is int"},
+		{"invalid type for printZeroValues", 1000, "test", "", "", true, 1, "error parsing printZeroValues, type is int"},
 	}
 
 	for _, tc := range testCases {

--- a/expression/functions_date_test.go
+++ b/expression/functions_date_test.go
@@ -532,7 +532,7 @@ func TestSplitFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := splitFormat(tc.format, tc.separator)
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("getFormattedDuration() test with name \"%v\" returned \"%v\", want \"%v\"", tc.name, got, tc.want)
+				t.Errorf("splitFormat() test with name \"%v\" returned \"%v\", want \"%v\"", tc.name, got, tc.want)
 			}
 		})
 	}
@@ -563,7 +563,7 @@ func TestInsertCalculatedUnit(t *testing.T) {
 					tc.durationFormatSplited, tc.format, tc.regex, tc.printZeroValues,
 				)
 			if got1 != tc.want1 || got2 != tc.want2 || !reflect.DeepEqual(got3, tc.want3) {
-				t.Errorf("getFormattedDuration() test with name \"%v\" returned {%v, %v, %v}, want {%v, %v, %v}",
+				t.Errorf("insertCalculatedUnit() test with name \"%v\" returned {%v, %v, %v}, want {%v, %v, %v}",
 					tc.name, got1, got2, got3, tc.want1, tc.want2, tc.want3,
 				)
 			}
@@ -590,7 +590,7 @@ func TestAsMilliseconds(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := asMilliseconds(tc.duration, tc.inputUnit)
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("getFormattedDuration() test with name \"%v\" returned \"%v\", want \"%v\"", tc.name, got, tc.want)
+				t.Errorf("asMilliseconds() test with name \"%v\" returned \"%v\", want \"%v\"", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/expression/functions_math.go
+++ b/expression/functions_math.go
@@ -209,13 +209,13 @@ func roundToDecimal(input interface{}, decimalPlaces interface{}) (interface{}, 
 	return rounded / math.Pow(10, float64(intDecimalPlaces)), nil
 }
 
-func safeDivide(dividende interface{}, divider interface{}) float64 {
-	floatDividende, _ := convertAsFloat(dividende)
-	floatDivider, err := convertAsFloat(divider)
+func safeDivide(dividend interface{}, divisor interface{}) float64 {
+	floatDividend, _ := convertAsFloat(dividend)
+	floatDivisor, err := convertAsFloat(divisor)
 
 	if err != nil {
 		return 0
 	}
 
-	return floatDividende / floatDivider
+	return floatDividend / floatDivisor
 }

--- a/expression/functions_math.go
+++ b/expression/functions_math.go
@@ -209,24 +209,13 @@ func roundToDecimal(input interface{}, decimalPlaces interface{}) (interface{}, 
 	return rounded / math.Pow(10, float64(intDecimalPlaces)), nil
 }
 
-func convertAsFloat(value interface{}) float64 {
-	switch v := value.(type) {
-	case int, int32, int64:
-		return float64(v.(int))
-	case float32, float64:
-		return v.(float64)
-	default:
-		return 0
-	}
-}
+func safeDivide(dividende interface{}, divider interface{}) float64 {
+	floatDividende, _ := convertAsFloat(dividende)
+	floatDivider, err := convertAsFloat(divider)
 
-func safeDivide(divider interface{}, dividende interface{}) float64 {
-	floatDivider := convertAsFloat(divider)
-	floatDividende := convertAsFloat(dividende)
-
-	if floatDividende == float64(0) {
+	if err != nil {
 		return 0
 	}
 
-	return floatDivider / floatDividende
+	return floatDividende / floatDivider
 }

--- a/expression/gval_test.go
+++ b/expression/gval_test.go
@@ -433,10 +433,16 @@ func TestEvalGetFormattedDuration(t *testing.T) {
 			expectedResult: "0 ms",
 		},
 		{
+			name:           "valid duration as a string",
+			expression:     "get_formatted_duration(a, \"ms\", \"{ms} ms\", \"\", false, true)",
+			variables:      map[string]interface{}{"a": "1000"},
+			expectedResult: "1000 ms",
+		},
+		{
 			name:           "invalid type",
 			expression:     "get_formatted_duration(a, \"test\", 100, 0, 1, 1)",
 			variables:      map[string]interface{}{"a": "test"},
-			expectedResult: "error",
+			expectedResult: "error parsing duration, value given is test, of type string",
 		},
 	}
 

--- a/expression/utils.go
+++ b/expression/utils.go
@@ -1,8 +1,10 @@
 package expression
 
 import (
+	"errors"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -48,4 +50,36 @@ func AssertNotEqual(t *testing.T, a interface{}, b interface{}, message ...strin
 	t.Helper()
 	t.Errorf("%sReceived %v (type %v), expected != %v (type %v)", errorMessage, a, reflect.TypeOf(a), b, reflect.TypeOf(b))
 	t.FailNow()
+}
+
+func convertAsFloat(value interface{}) (float64, error) {
+	switch v := value.(type) {
+	case int, int32, int64:
+		return float64(v.(int)), nil
+	case float32, float64:
+		return v.(float64), nil
+	case string:
+		value, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, err
+		}
+		return value, nil
+	default:
+		return 0, errors.New("Unable to convert this type as a float64")
+	}
+}
+
+func convertAsBool(value interface{}) (bool, error) {
+	switch v := value.(type) {
+	case bool:
+		return bool(v), nil
+	case string:
+		value, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, err
+		}
+		return value, nil
+	default:
+		return false, errors.New("Unable to convert this type as a bool")
+	}
 }

--- a/expression/utils.go
+++ b/expression/utils.go
@@ -54,10 +54,16 @@ func AssertNotEqual(t *testing.T, a interface{}, b interface{}, message ...strin
 
 func convertAsFloat(value interface{}) (float64, error) {
 	switch v := value.(type) {
-	case int, int32, int64:
-		return float64(v.(int)), nil
-	case float32, float64:
-		return v.(float64), nil
+	case int:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case float32:
+		return float64(v), nil
+	case float64:
+		return float64(v), nil
 	case string:
 		value, err := strconv.ParseFloat(v, 64)
 		if err != nil {

--- a/expression/utils_test.go
+++ b/expression/utils_test.go
@@ -1,0 +1,60 @@
+package expression
+
+import (
+	"testing"
+)
+
+func TestConvertAsFloat(t *testing.T) {
+
+	testCases := []struct {
+		name  string
+		value interface{}
+		want  float64
+	}{
+		{"convert float as a float64", 1234.1, 1234.1},
+		{"convert string float as a float64", "1234.1", 1234.1},
+		{"convert int as float64", 1234, 1234},
+		{"convert string int as float64", "1234", 1234},
+
+		{"convert explicit int as a float64", int(1), 1},
+		{"convert explicit int32 as a float64", int32(1), 1},
+		{"convert explicit int64 as a float64", int64(1), 1},
+		{"convert explicit float32 as a float64", float32(1), 1},
+		{"convert explicit float64 as a float64", float64(1), 1},
+		{"invalid string", "test", 0},
+		{"invalid string", false, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got_value, got_err := convertAsFloat(tc.value)
+			if got_value != tc.want {
+				t.Errorf("convertAsFloat() test with name \"%v\" returned \"%v\", want \"%v\", error returned is %v", tc.name, got_value, tc.want, got_err)
+			}
+		})
+	}
+}
+func TestConvertAsBool(t *testing.T) {
+
+	testCases := []struct {
+		name  string
+		value interface{}
+		want  bool
+	}{
+		{"convert true as bool", true, true},
+		{"convert string true as bool", "true", true},
+		{"convert false as bool", false, false},
+		{"convert string false as bool", "false", false},
+		{"cannot convert string", "test", false},
+		{"cannot convert another type", 1, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got_value, got_err := convertAsBool(tc.value)
+			if got_value != tc.want {
+				t.Errorf("convertAsBool() test with name \"%v\" returned \"%v\", want \"%v\", error returned is %v", tc.name, got_value, tc.want, got_err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
improved and refactored gval func get_formatted_duration and safeDivide to use string for input parameters
duration and booleans can be given as a string value and would be converted instead of returning error