### PR TITLE
Add 'check previous set action ' flag to improve rule evaluation

### DIFF
--- a/ruleeng/action.go
+++ b/ruleeng/action.go
@@ -8,6 +8,7 @@ type Action interface {
 	GetMetaData() map[string]interface{}
 	GetEnabledDependsAction() bool
 	GetEnableDependsForALLAction() bool
+	GetCheckPrevSetAction() bool
 }
 
 // DefaultAction default action implementation
@@ -17,6 +18,7 @@ type DefaultAction struct {
 	MetaData                  map[string]interface{} `json:"metaData"`
 	EnabledDependsAction      bool                   `json:"enabledDepends"`
 	EnableDependsForALLAction bool                   `json:"enableDependsForALLAction"`
+	CheckPrevSetAction        bool                   `json:"checkPrevSetAction"`
 }
 
 // GetParameters returns the action parameters
@@ -42,4 +44,8 @@ func (a DefaultAction) GetEnabledDependsAction() bool {
 // GetEnableDependsForALLAction return if the case supports dependency management
 func (a DefaultAction) GetEnableDependsForALLAction() bool {
 	return a.EnableDependsForALLAction
+}
+
+func (a DefaultAction) GetCheckPrevSetAction() bool {
+	return a.CheckPrevSetAction
 }

--- a/ruleeng/rueleeng_test.go
+++ b/ruleeng/rueleeng_test.go
@@ -523,6 +523,7 @@ var ruleStr = `{
 		"name": "case1",
 		"enabled": true,
 		"condition": "fact_test_1.aggs.agg0.value == fact_test_1.aggs.doc_count.value",
+        "checkprevsetaction": true,		
 		"actions": [
 		  {
 			"name": "\"set\"",

--- a/ruleeng/rule.go
+++ b/ruleeng/rule.go
@@ -94,6 +94,7 @@ type Case struct {
 	Actions                   []ActionDef `json:"actions"`
 	Enabled                   bool        `json:"enabled"`
 	EnableDependsForALLAction bool        `json:"enableDependsForALLAction"`
+	CheckPrevSetAction        bool        `json:"checkPrevSetAction"` // CheckPrevSet indicates whether to verify the previously set action parameters in the rule evaluation process.
 }
 
 func (c Case) evaluate(k KnowledgeBase) []DefaultAction {
@@ -114,7 +115,7 @@ func resolve(c Case, k KnowledgeBase) []DefaultAction {
 		if !a.Enabled {
 			continue
 		}
-		rAction, err := a.Resolve(k, c.EnableDependsForALLAction)
+		rAction, err := a.Resolve(k, c)
 		if err == nil {
 			rAction.MetaData["caseName"] = c.Name
 			resolvedActions = append(resolvedActions, rAction)
@@ -161,7 +162,7 @@ type ActionDef struct {
 }
 
 // Resolve resolves the ActionDef into a DefaultAction
-func (a ActionDef) Resolve(k KnowledgeBase, EnableDependsForALLAction bool) (DefaultAction, error) {
+func (a ActionDef) Resolve(k KnowledgeBase, c Case) (DefaultAction, error) {
 
 	name, err := a.Name.EvaluateAsString(k)
 
@@ -174,7 +175,8 @@ func (a ActionDef) Resolve(k KnowledgeBase, EnableDependsForALLAction bool) (Def
 		Parameters:                make(map[string]interface{}),
 		MetaData:                  make(map[string]interface{}),
 		EnabledDependsAction:      a.EnabledDepends,
-		EnableDependsForALLAction: EnableDependsForALLAction,
+		EnableDependsForALLAction: c.EnableDependsForALLAction,
+		CheckPrevSetAction:        c.CheckPrevSetAction,
 	}
 
 	for key, exp := range a.Parameters {


### PR DESCRIPTION
Introduced the `CheckPrevSetAction` field in `Case` and `DefaultAction` to enable verification of previously set action parameters during rule evaluation. Updated related methods (`Resolve` and interface implementations) to incorporate this new flag. Added necessary test coverage to validate the functionality.