### PR TITLE
Improve time zone handling in date histogram aggregations

### DIFF
--- a/elasticsearch/search_request.go
+++ b/elasticsearch/search_request.go
@@ -86,6 +86,10 @@ func buildElasticBucket(name string, intent types.Aggregations, dimensions []*en
 				Field: some.String(frag.Term),
 			}
 
+			if frag.TimeZone != "" {
+				histogramAgg.TimeZone = &frag.TimeZone
+			}
+
 			// Fixed interval
 			if frag.CalendarFixed {
 				if frag.DateInterval == "" {

--- a/engine/fact.go
+++ b/engine/fact.go
@@ -124,7 +124,7 @@ func (f *Fact) IsExecutable() bool {
 // ContextualizeDimensions contextualize fact dimensions placeholders (standard or custom) and set the right timezone if needed
 func (f *Fact) ContextualizeDimensions(t time.Time) {
 	for _, dim := range f.Dimensions {
-		if dim.Operator == DateHistogram {
+		if dim.Operator == DateHistogram && dim.TimeZone == "" {
 			dim.TimeZone = utils.GetTimeZone(t)
 		}
 	}


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of time zones in date histogram operations. The updates ensure that time zones are properly set and utilized in both the Elasticsearch request building process and the contextualization of fact dimensions.

### Enhancements to time zone handling:

* [`elasticsearch/search_request.go`](diffhunk://#diff-81f024741cfb08ccc886bc128bf604868fef50cda89124162ae87ffa4015f120R89-R92): Added logic to set the `TimeZone` field in the `histogramAgg` object if the `frag.TimeZone` value is not empty. This ensures that the time zone is included in the Elasticsearch aggregation request when specified.

* [`engine/fact.go`](diffhunk://#diff-4df86d6e90dab434800cd0fb3c88f5da00c3caaa6981de9e6296036e4847df2eL127-R127): Updated the `ContextualizeDimensions` method to only set a default time zone using `utils.GetTimeZone` if the `TimeZone` field is empty for dimensions with the `DateHistogram` operator. This prevents overwriting an already defined time zone.