### PR TITLE
Add cron_threshold to return a value based on active cron schedule and validity duration

### DIFF
--- a/expression/functions_cron.go
+++ b/expression/functions_cron.go
@@ -1,0 +1,151 @@
+package expression
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+// cronThreshold returns the threshold of the highest-priority entry whose active window contains now,
+// or defaultThreshold if none match.
+//
+// An entry is active when: lastFire <= now < lastFire + duration,
+// where lastFire is the most recent cron fire time at or before now.
+//
+// When multiple entries match, the one with the highest priority wins.
+// Entries with equal priority are resolved by order (first one wins).
+//
+// Usage: cron_threshold(now, defaultThreshold, entry1, entry2, ...)
+//
+// Important: this function evaluates cron schedules against `now` in UTC.
+// Cron expressions must therefore be defined in UTC (not local time).
+//
+// Each entry is a map with:
+//   - "cron"      (required) : cron expression string, e.g. "0 5 * * *"
+//   - "duration"  (required) : duration string, e.g. "1h", "30m", "17h"
+//   - "threshold" (required) : number
+//   - "priority"  (optional) : number, default 0 — higher value wins on conflict
+//
+// Example:
+//
+//	cron_threshold(now, 0,
+//	    {"cron": "0 5 * * *",   "duration": "1h",  "threshold": 1000},
+//	    {"cron": "0 0 * * *",   "duration": "1h",  "threshold": 3000, "priority": 10},
+//	    {"cron": "0 7 * * 1-6", "duration": "17h", "threshold": 1}
+//	)
+func cronThreshold(arguments ...interface{}) (interface{}, error) {
+	if len(arguments) < 2 {
+		return nil, fmt.Errorf("cron_threshold() expects at least 2 arguments: now and defaultThreshold")
+	}
+
+	// Parse now
+	nowStr, ok := arguments[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("cron_threshold() expects first argument (now) to be a string date")
+	}
+	now, _, err := parseDateAllFormat(nowStr)
+	if err != nil {
+		return nil, fmt.Errorf("cron_threshold() cannot parse now: %s", err.Error())
+	}
+
+	// Parse defaultThreshold
+	defaultThreshold, ok := toFloat64(arguments[1])
+	if !ok {
+		return nil, fmt.Errorf("cron_threshold() expects second argument (defaultThreshold) to be a number")
+	}
+
+	var (
+		bestThreshold = defaultThreshold
+		bestPriority  = -1.0 // sentinel: no match yet
+		matched       = false
+	)
+
+	for i, arg := range arguments[2:] {
+		entry, ok := arg.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cron_threshold() entry %d must be a map", i+1)
+		}
+
+		cronExpr, err := requireString(entry, "cron", i+1)
+		if err != nil {
+			return nil, err
+		}
+		durationStr, err := requireString(entry, "duration", i+1)
+		if err != nil {
+			return nil, err
+		}
+		threshold, err := requireNumber(entry, "threshold", i+1)
+		if err != nil {
+			return nil, err
+		}
+		priority := 0.0
+		if p, exists := entry["priority"]; exists {
+			priority, ok = toFloat64(p)
+			if !ok {
+				return nil, fmt.Errorf("cron_threshold() entry %d: \"priority\" must be a number", i+1)
+			}
+		}
+
+		duration, err := time.ParseDuration(durationStr)
+		if err != nil {
+			return nil, fmt.Errorf("cron_threshold() entry %d: cannot parse duration %q: %s", i+1, durationStr, err.Error())
+		}
+		if duration <= 0 {
+			return nil, fmt.Errorf("cron_threshold() entry %d: duration must be positive, got %q", i+1, durationStr)
+		}
+
+		schedule, err := cronParser.Parse(cronExpr)
+		if err != nil {
+			return nil, fmt.Errorf("cron_threshold() entry %d: cannot parse cron %q: %s", i+1, cronExpr, err.Error())
+		}
+
+		// Find the last cron fire time at or before now by iterating forward
+		// from (now - duration), then check if now falls within [lastFire, lastFire + duration).
+		var lastFire time.Time
+		t := schedule.Next(now.Add(-duration).Add(-time.Nanosecond))
+		for !t.After(now) {
+			lastFire = t
+			t = schedule.Next(t)
+		}
+		if lastFire.IsZero() || !now.Before(lastFire.Add(duration)) {
+			continue
+		}
+
+		// This entry matches — keep it if it has a higher priority than the current best,
+		// or if it's the first match (matched == false).
+		if !matched || priority > bestPriority {
+			bestThreshold = threshold
+			bestPriority = priority
+			matched = true
+		}
+	}
+
+	return bestThreshold, nil
+}
+
+func requireString(entry map[string]interface{}, key string, entryIndex int) (string, error) {
+	v, exists := entry[key]
+	if !exists {
+		return "", fmt.Errorf("cron_threshold() entry %d: missing required field %q", entryIndex, key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("cron_threshold() entry %d: field %q must be a string", entryIndex, key)
+	}
+	return s, nil
+}
+
+func requireNumber(entry map[string]interface{}, key string, entryIndex int) (float64, error) {
+	v, exists := entry[key]
+	if !exists {
+		return 0, fmt.Errorf("cron_threshold() entry %d: missing required field %q", entryIndex, key)
+	}
+	n, ok := toFloat64(v)
+	if !ok {
+		return 0, fmt.Errorf("cron_threshold() entry %d: field %q must be a number", entryIndex, key)
+	}
+	return n, nil
+}

--- a/expression/functions_cron_test.go
+++ b/expression/functions_cron_test.go
@@ -1,0 +1,240 @@
+package expression
+
+import (
+	"testing"
+)
+
+func TestCronThreshold(t *testing.T) {
+	entry := func(cronExpr, duration string, threshold float64, priority ...float64) map[string]interface{} {
+		m := map[string]interface{}{
+			"cron":      cronExpr,
+			"duration":  duration,
+			"threshold": threshold,
+		}
+		if len(priority) > 0 {
+			m["priority"] = priority[0]
+		}
+		return m
+	}
+
+	tests := []struct {
+		name    string
+		now     string
+		def     float64
+		entries []map[string]interface{}
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "inside 5h-6h window",
+			now:  "2024-01-15T05:30:00Z",
+			def:  0,
+			entries: []map[string]interface{}{
+				entry("0 5 * * *", "1h", 1000),
+				entry("0 7 * * 1-6", "17h", 3000),
+			},
+			want: 1000,
+		},
+		{
+			name:    "at exact cron fire time",
+			now:     "2024-01-15T05:00:00Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("0 5 * * *", "1h", 1000)},
+			want:    1000,
+		},
+		{
+			name:    "just before window ends",
+			now:     "2024-01-15T05:59:59Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("0 5 * * *", "1h", 1000)},
+			want:    1000,
+		},
+		{
+			name:    "just at window end (exclusive)",
+			now:     "2024-01-15T06:00:00Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("0 5 * * *", "1h", 1000)},
+			want:    0,
+		},
+		{
+			name: "inside 7h-0h weekday window",
+			now:  "2024-01-15T14:00:00Z",
+			def:  0,
+			entries: []map[string]interface{}{
+				entry("0 5 * * *", "1h", 1000),
+				entry("0 7 * * 1-6", "17h", 3000),
+			},
+			want: 3000,
+		},
+		{
+			name: "sunday: no match returns default",
+			now:  "2024-01-14T14:00:00Z",
+			def:  0,
+			entries: []map[string]interface{}{
+				entry("0 5 * * *", "1h", 1000),
+				entry("0 7 * * 1-6", "17h", 3000),
+			},
+			want: 0,
+		},
+		{
+			name:    "midnight window",
+			now:     "2024-01-15T00:30:00Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("0 0 * * *", "1h", 3000)},
+			want:    3000,
+		},
+		{
+			name:    "no entries returns default",
+			now:     "2024-01-15T05:30:00Z",
+			def:     42,
+			entries: nil,
+			want:    42,
+		},
+		{
+			// Two entries match: second has higher priority
+			name: "priority: higher priority wins",
+			now:  "2024-01-15T05:30:00Z",
+			def:  0,
+			entries: []map[string]interface{}{
+				entry("0 5 * * *", "1h", 1000, 1),
+				entry("* * * * *", "1h", 9999, 5), // also matches, higher priority
+			},
+			want: 9999,
+		},
+		{
+			// Two entries match with equal priority: first wins
+			name: "priority: equal priority keeps first",
+			now:  "2024-01-15T05:30:00Z",
+			def:  0,
+			entries: []map[string]interface{}{
+				entry("0 5 * * *", "1h", 1000, 1),
+				entry("* * * * *", "1h", 9999, 1),
+			},
+			want: 1000,
+		},
+		{
+			name:    "invalid cron expression",
+			now:     "2024-01-15T05:30:00Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("not-a-cron", "1h", 1000)},
+			wantErr: true,
+		},
+		{
+			name:    "invalid duration",
+			now:     "2024-01-15T05:30:00Z",
+			def:     0,
+			entries: []map[string]interface{}{entry("0 5 * * *", "bad", 1000)},
+			wantErr: true,
+		},
+		{
+			name:    "missing cron field",
+			now:     "2024-01-15T05:30:00Z",
+			def:     0,
+			entries: []map[string]interface{}{{"duration": "1h", "threshold": float64(1000)}},
+			wantErr: true,
+		},
+		{
+			name:    "missing threshold field",
+			now:     "2024-01-15T05:30:00Z",
+			def:     0,
+			entries: []map[string]interface{}{{"cron": "0 5 * * *", "duration": "1h"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []interface{}{tt.now, tt.def}
+			for _, e := range tt.entries {
+				args = append(args, e)
+			}
+
+			got, err := cronThreshold(args...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("cronThreshold() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				val, ok := toFloat64(got)
+				if !ok {
+					t.Errorf("cronThreshold() returned non-numeric value: %v", got)
+					return
+				}
+				if val != tt.want {
+					t.Errorf("cronThreshold() = %v, want %v", val, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCronThresholdViaGval(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		vars       map[string]interface{}
+		want       float64
+	}{
+		{
+			name: "5h-6h window",
+			expression: `cron_threshold(now, 0,
+				{"cron": "0 5 * * *",   "duration": "1h",  "threshold": 1000},
+				{"cron": "0 0 * * *",   "duration": "1h",  "threshold": 3000},
+				{"cron": "0 7 * * 1-6", "duration": "17h", "threshold": 1})`,
+			vars: map[string]interface{}{"now": "2024-01-15T05:45:00Z"},
+			want: 1000,
+		},
+		{
+			name: "midnight window",
+			expression: `cron_threshold(now, 0,
+				{"cron": "0 5 * * *",   "duration": "1h",  "threshold": 1000},
+				{"cron": "0 0 * * *",   "duration": "1h",  "threshold": 3000},
+				{"cron": "0 7 * * 1-6", "duration": "17h", "threshold": 1})`,
+			vars: map[string]interface{}{"now": "2024-01-15T00:30:00Z"},
+			want: 3000,
+		},
+		{
+			name: "weekday daytime",
+			expression: `cron_threshold(now, 0,
+				{"cron": "0 5 * * *",   "duration": "1h",  "threshold": 1000},
+				{"cron": "0 0 * * *",   "duration": "1h",  "threshold": 3000},
+				{"cron": "0 7 * * 1-6", "duration": "17h", "threshold": 1})`,
+			vars: map[string]interface{}{"now": "2024-01-15T14:00:00Z"},
+			want: 1,
+		},
+		{
+			name: "sunday uses default",
+			expression: `cron_threshold(now, 999,
+				{"cron": "0 5 * * *",   "duration": "1h",  "threshold": 1000},
+				{"cron": "0 7 * * 1-6", "duration": "17h", "threshold": 1})`,
+			vars: map[string]interface{}{"now": "2024-01-14T14:00:00Z"},
+			want: 999,
+		},
+		{
+			name: "priority resolves conflict",
+			expression: `cron_threshold(now, 0,
+				{"cron": "0 5 * * *", "duration": "1h", "threshold": 1000, "priority": 1},
+				{"cron": "* * * * *", "duration": "1h", "threshold": 9999, "priority": 5})`,
+			vars: map[string]interface{}{"now": "2024-01-15T05:30:00Z"},
+			want: 9999,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Process(LangEval, tt.expression, tt.vars)
+			if err != nil {
+				t.Errorf("Process() error = %v", err)
+				return
+			}
+			val, ok := toFloat64(result)
+			if !ok {
+				t.Errorf("Process() returned non-numeric value: %v", result)
+				return
+			}
+			if val != tt.want {
+				t.Errorf("Process() = %v, want %v", val, tt.want)
+			}
+		})
+	}
+}

--- a/expression/gval.go
+++ b/expression/gval.go
@@ -74,6 +74,7 @@ var (
 		gval.Function("numberWithoutExponent", numberWithoutExponent),
 		gval.Function("once_today_at_hour", onceTodayAtHour),
 		gval.Function("generate_time_range_indexes", generateTimeRangeIndexes),
+		gval.Function("cron_threshold", cronThreshold),
 	)
 
 	// LangEvalDateOpenDays is a custom GVal evaluator for business rules and facts conditions


### PR DESCRIPTION
Add `cron_threshold` function for evaluating active cron schedules

- Implements the `cron_threshold` utility to select the threshold of the highest-priority active schedule.
- Adds corresponding tests for function validation.
- Registers the function within the GVal configuration.