### PR TITLE
Add appendOnly parameter to bulkIngestRequest struct

### DIFF
--- a/connector/sink.go
+++ b/connector/sink.go
@@ -13,6 +13,10 @@ type BulkIngestRequest struct {
 	DocumentType string     `json:"documentType"`
 	MergeConfig  []Config   `json:"merge"`
 	Docs         []Document `json:"docs"`
+	// AppendOnly disables any document lookup (mget) before indexing.
+	// When true, documents are inserted directly without merging with existing ones.
+	// This is ideal for append-only workloads such as logs. Defaults to false.
+	AppendOnly bool `json:"appendOnly"`
 }
 
 // Document represent an es document


### PR DESCRIPTION
This pull request adds support for append-only bulk ingest operations in the `BulkIngestRequest` struct. The main change is the introduction of an `AppendOnly` flag, which allows documents to be inserted directly without merging or looking up existing ones, making it suitable for append-only workloads like logs.

Bulk ingest improvements:
* Added an `AppendOnly` boolean field to the `BulkIngestRequest` struct in `connector/sink.go`, along with documentation explaining its purpose and default behavior.